### PR TITLE
Implemented .flatten() method for Arrays.

### DIFF
--- a/Packages/Core/ArrayUtil.blz
+++ b/Packages/Core/ArrayUtil.blz
@@ -44,7 +44,7 @@ end
 :each(arr, method)
 	length = arr.length()
 	for i = 0; i < length; i++
-		method(arr[i], i)
+		method(arr[i])
 	end
 	return arr
 end
@@ -71,9 +71,9 @@ end
 end
 
 :map(arr, method)
-	length = arr.length!()
-	for i = 0; i < arr.length!(); i++
-		arr[i] = method!(arr[i])
+	length = arr.length()
+	for i = 0; i < length; i++
+		arr[i] = method(arr[i])
 	end
 	arr
 end
@@ -82,6 +82,7 @@ end
 	return false
 end
 
+#does not work with !
 :remove(arr, index)
 	newarr = []
 	len = arr.length() - 1
@@ -197,19 +198,14 @@ end
 	arr[random(arr.length())]
 end
 
-:any?(arr)
-	arr.contains!?(true)
-end
-
-:index_of(arr, element)
-	for i = 0; i < arr.length(); i++
-		if arr[i] == element
-			return i
-		end
-	end
-	-1
-end
-
-:append(arr, second)
-	arr.concatenate!(second)
+:flatten(arr)
+    result = []
+    count = 0
+    for i = 0; i < arr.length(); i++
+        for j = 0; j < arr[i].length(); j++
+            result[count] = arr[i][j]
+            count++
+        end
+    end
+    return result
 end


### PR DESCRIPTION
Fixed Issue#39
Standard library method flat / flatten
[[1, 2], [3,4]].flatten() now returns [1, 2, 3, 4]