### PR TITLE
Implemented the flatten method for Arrays

### DIFF
--- a/Packages/Core/ArrayUtil.blz
+++ b/Packages/Core/ArrayUtil.blz
@@ -213,3 +213,15 @@ end
 :append(arr, second)
 	arr.concatenate!(second)
 end
+
+:flatten(arr)
+    result = []
+    count = 0
+    for i = 0; i < arr.length(); i++
+        for j = 0; j < arr[i].length(); j++
+            result[count] = arr[i][j]
+            count++
+        end
+    end
+    return result
+end


### PR DESCRIPTION
Fixed Issue#39
Standard library method flat / flatten
[[1, 2], [3,4]].flatten() now returns [1, 2, 3, 4]

This one should be the final one.  😆 